### PR TITLE
add Dockerfile

### DIFF
--- a/Docker/.dockerignore
+++ b/Docker/.dockerignore
@@ -1,0 +1,1 @@
+docker-deezy-auto-earn.code-workspace

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:3.17 AS build-env
+
+RUN apk add --update --no-cache git
+
+RUN git clone --depth 1 https://github.com/dannydeezy/deezy-auto-earn /deezy-auto-earn
+
+FROM node:current-alpine
+
+COPY --from=build-env /deezy-auto-earn/ /deezy-auto-earn/
+COPY entrypoint.sh entrypoint.sh
+
+RUN cd /deezy-auto-earn \
+    && npm i \
+    && chmod +x /entrypoint.sh
+
+VOLUME [ "/lnd", "/config" ]
+
+WORKDIR /deezy-auto-earn
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Docker/docker-deezy-auto-earn.code-workspace
+++ b/Docker/docker-deezy-auto-earn.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"files.eol": "\n"
+	}
+}

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ -f /config/config.json ]
+then
+    cp /config/config.json /deezy-auto-earn/config.json
+    cd /deezy-auto-earn
+    node index.js
+else
+    echo "Couldn't find a config file..."
+    exit
+fi


### PR DESCRIPTION
This Dockerfile allows running deezy-auto-earn without having to manage npm/node. A serious advantage especially if running docker already. 
This also enables deezy-auto-earn on Umbrel installations and other hosts utilizing docker at their core.
I built the image and uploaded it to dockerhub as an example and for testing here: https://hub.docker.com/repository/docker/aphex3k/deezy-auto-earn

```
➜  umbrel git:(master) ✗ docker run --name deezy-auto-earn --rm --network="umbrel_main_network" -v /home/umbrel/deezy-auto-earn/:/config/:ro -v /home/umbrel/umbrel/app-data/lightning/data/lnd/:/lnd/:ro aphex3k/deezy-auto-earn:latest
(node:7) [DEP0123] DeprecationWarning: Setting the TLS ServerName to an IP address is not permitted by RFC 6066. This will be ignored in a future version.
(Use `node --trace-deprecation ...` to show where the warning was created)
Already connected to deezy
Fetching channel info
Found 1 locally initiated channel(s) with deezy
Checking if any deezy channels are ready to close
Requesting earn and close for deezy channel: <redacted>:1
{
  channel_point: '<redacted>:1',
  payout_ppm: 1111,
  payout_payment_hash: '<redacted>',
  status: 'PENDING'
}
Attempted to earn and close channel, terminating here.
```


## Docker Build
```
docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x -t "aphex3k/deezy-auto-earn:latest" --push .
```

## Umbrel Run Example
```
docker run --name deezy-auto-earn --rm --network="umbrel_main_network" -v /home/umbrel/deezy-auto-earn/:/config/:ro -v /home/umbrel/umbrel/app-data/lightning/data/lnd/:/lnd/:ro aphex3k/deezy-auto-earn:latest
```
### Umbrel Config Example
```
{
    "CLOSE_WHEN_CHANNEL_EXCEEDS_RATIO": 0.95,
    "DEEZY_CHANNEL_SIZE_SATS": 10000000,
    "OPEN_CHANNEL_WHEN_LOCAL_SATS_BELOW": 5006118,
    "PRIVATE_CHANNEL": false,
    "MAX_CHANNEL_OPEN_FEE_SATS_PER_VBYTE": 1,
    "TLS_CERT_PATH": "/lnd/tls.cert",
    "MACAROON_PATH": "/lnd/data/chain/bitcoin/mainnet/admin.macaroon",
    "SOCKET": "10.21.21.9:10009",
    "DESTINATIONS": [
        {
            "TYPE": "LNURL",
            "LNURL_OR_ADDRESS": "",
            "MAX_ROUTE_FEE_PPM": 10,
            "PAYMENT_AMOUNT_SATS": 925000
        }
    ]
}

```

Put the config.json in the `/home/umbrel/deezy-auto-earn/` folder and you are up and running.