### PR TITLE
Variable payment size Issue #5

### DIFF
--- a/sample-config.json
+++ b/sample-config.json
@@ -14,7 +14,10 @@
             "TYPE": "LNURL",
             "LNURL_OR_ADDRESS": "timelyhail89@walletofsatoshi.com",
             "MAX_ROUTE_FEE_PPM": 700,
-            "PAYMENT_AMOUNT_SATS": 50000
+            "PAYMENT_AMOUNT_SATS": 50000,
+            "MIN_PAYMENT_AMOUNT_SATS": 25000,
+            "MAX_PAYMENT_AMOUNT_SATS": 250000,
+            "PAYMENT_MULTIPLIER":2
         },
         {
             "TYPE": "BITFINEX",


### PR DESCRIPTION
Took a stab at https://github.com/dannydeezy/deezy-auto-earn/issues/5

The idea is _if_ payment_amount_sats is NOT set, then we leverage the minimum and maximum values.

The way we use the min/max payments is we start with the largest payment size, and then divide by the PAYMENT_MULTIPLIER on each subsequent attempt.

For example, lets say our max payment size is 8. And our multiplier is 2. And we are making our 3rd attempt. We need to divide 8 by 2, 3 times, which means we would attempt a payment for size 1.